### PR TITLE
[n/a] add configuration file for redis to up the limit of database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Docker for Proximis [![Build Status](https://travis-ci.org/EmakinaFR/docker-proximis.svg?branch=master)](https://travis-ci.org/EmakinaFR/docker-proximis)
+
 This repository allows the creation of a Docker environment that meets
-[Proximis Omnichannel](https://www.proximis.com/solution-online/) requirements.
+[Proximis Omnichannel](https://www.proximis.com/) requirements.
 
 ## Architecture
+
 Here are the environment containers:
 
 * `nginx`: [nginx:stable](https://hub.docker.com/_/nginx/) image.
@@ -28,6 +30,7 @@ proximis_redis_1           docker-entrypoint.sh redis ...   Up      0.0.0.0:6379
 ```
 
 ## Installation
+
 This process assumes that depending of your OS, [Docker for Mac](https://www.docker.com/products/docker#/mac), [Docker for Windows](https://www.docker.com/products/docker#/windows) or [Docker for linux](https://www.docker.com/products/docker#/linux) is installed.
 Otherwise, [Docker Toolbox](https://www.docker.com/toolbox) should be installed before proceeding.
 The path to the local shared folder is `~/www` by default.
@@ -35,54 +38,70 @@ The path to the local shared folder is `~/www` by default.
 After the installation, the Proximis application is reachable by using [`http://proximis.localhost/`](http://proximis.localhost/).
 
 ### Clone the repository
+
 ```bash
 $ git clone git@github.com:EmakinaFR/docker-proximis.git proximis
 ```
+
 It's also possible to download this repository as a
 [ZIP archive](https://github.com/EmakinaFR/docker-proximis/archive/master.zip).
 
 ### Define the environment variables
+
 ```bash
 $ cp docker-env.dist docker-env
 $ nano docker-env
 ```
+
 The only mandatory environment variable is: __MYSQL_ROOT_PASSWORD__.
 
 ### Start the environment
 
 #### With Docker for mac/windows/linux
+
 ```bash
 $ docker-compose start
 ```
+
 #### With Docker Toolbox
 
 ##### Create the virtual machine
+
 ```bash
 $ docker-machine create --driver=virtualbox proximis
 $ eval "$(docker-machine env proximis)"
 ```
+
 ##### Build the environment
+
 ```bash
 $ docker-compose up -d
 ```
 
 ### Update the `/etc/hosts` file
+
 ```bash
 $ docker-machine ip proximis | sudo sh -c 'echo "$(awk {"print $1"})  proximis.localhost" >> /etc/hosts'
 ```
+
 This command add automatically the virtual machine IP address in the `/etc/hosts` file.
 
 ### Configuration of the Proximis project
+
 This operation can be achieved through the PHP-FPM container.
+
 ```bash
 $ docker-compose exec php /bin/bash
 ```
-Once in the container, the [official documentation](http://doc.change-commerce.com/) explains all the remaining steps.
+
+Once in the container, the [official documentation](http://doc.omn.proximis.com/) explains all the remaining steps.
 
 ## Custom configuration
+
 The path to the local shared folder can be changed by editing the `docker-compose.yml` file.
 
-It's also possible to automatically define Nginx servers and the PHP configuration. When the environment is built:
+It's also possible to automatically define Nginx servers, PHP or Redis configuration. When the environment is built:
 
 * `*.conf` files located under the `nginx` directory are copied to `/etc/nginx/conf.d/`,
 * `*.ini` files located under the `php` directory are copied to `/usr/local/etc/php/conf.d/`.
+* `redis.conf` file located under the `redis` directory is copied to `/usr/local/etc/redis/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "9200:9200"
       - "9300:9300"
     volumes:
-      - elasticsearch:/usr/share/elasticsearch/data
+      - elasticsearch:/usr/share/elasticsearch/data:rw
       - ./elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - ./elasticsearch/log4j2.properties:/usr/share/elasticsearch/config/log4j2.properties
     tty: true
@@ -60,7 +60,7 @@ services:
       - ./kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml
 
   redis:
-    image: redis:latest
+    build: redis
     env_file: docker-env
     ports:
       - "6379:6379"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:stable
 
-MAINTAINER Alexandre JARDIN <aja@emakina.fr>
+LABEL maintainer="EmakinaFR <team-proximis@emakina.fr>"
 
 RUN usermod -u 1000 www-data

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,8 +1,6 @@
 FROM php:7.1-fpm
 
-MAINTAINER Alexandre JARDIN <aja@emakina.fr>
-MAINTAINER Thibault DESMOULINS <tds@emakina.fr>
-MAINTAINER Romain MONTEIL <rmo@emakina.fr>
+LABEL maintainer="EmakinaFR <team-proximis@emakina.fr>"
 
 COPY *.ini /usr/local/etc/php/conf.d/
 

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,0 +1,8 @@
+FROM redis:latest
+
+LABEL maintainer="EmakinaFR <team-proximis@emakina.fr>"
+
+# Install custom Redis configuration
+COPY redis.conf /usr/local/etc/redis/redis.conf
+
+CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,0 +1,1 @@
+databases 100


### PR DESCRIPTION
By default, Redis limits the number of databases to 16. I have increased this limit to 100 so that I can apply index ranges from 20 to 20 per project/brand